### PR TITLE
Fix week summary not updating on update

### DIFF
--- a/Nulah.TimeTracker/Controls/DateView.axaml
+++ b/Nulah.TimeTracker/Controls/DateView.axaml
@@ -38,7 +38,15 @@
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Border Name="DateParent" Background="Transparent">
+                        <Border Name="DateParent" Classes.IsActive="{Binding Selected}">
+                            <Border.Styles>
+                                <Style Selector="Border">
+                                    <Setter Property="Background" Value="Transparent" />
+                                </Style>
+                                <Style Selector="Border.IsActive">
+                                    <Setter Property="Background" Value="Aqua" />
+                                </Style>
+                            </Border.Styles>
                             <i:Interaction.Behaviors>
                                 <ia:EventTriggerBehavior
                                     EventName="PointerReleased"

--- a/Nulah.TimeTracker/Controls/DateView.axaml.cs
+++ b/Nulah.TimeTracker/Controls/DateView.axaml.cs
@@ -127,7 +127,7 @@ public class DateViewModel : ViewModelBase
 			{
 				LoadWeekFromDate(DateTimeOffset.Now);
 
-				SelectedTimeSummary = LoadedWeekSummaryCache.Lookup(DateTimeOffset.Now.Date).Value;
+				UpdateSelectedSummary(LoadedWeekSummaryCache.Lookup(DateTimeOffset.Now.Date).Value);
 
 				LoadSelectedTimeEntriesForDate(DateTimeOffset.Now.Date, _timeManager);
 			});
@@ -173,7 +173,7 @@ public class DateViewModel : ViewModelBase
 		{
 			Dispatcher.UIThread.Invoke(() =>
 			{
-				SelectedTimeSummary = summarisedTimeEntryViewModel;
+				UpdateSelectedSummary(summarisedTimeEntryViewModel);
 				if (summarisedTimeEntryViewModel != null)
 				{
 					LoadSelectedTimeEntriesForDate(new DateTimeOffset(summarisedTimeEntryViewModel.SummarisedTimeEntryDto.Date, DateTimeOffset.Now.Offset), _timeManager);
@@ -189,7 +189,7 @@ public class DateViewModel : ViewModelBase
 			Dispatcher.UIThread.Invoke(() =>
 			{
 				// Do we have a weekday summary selected, and would it contain our new entry?
-				if (SelectedTimeSummary != null && SelectedTimeSummary.SummarisedTimeEntryDto.Date != createdTimeEntry.Start.Date)
+				if (_selectedTimeSummary != null && _selectedTimeSummary.SummarisedTimeEntryDto.Date != createdTimeEntry.Start.Date)
 				{
 					// The currently selected summary isn't for this time entry, find if any other loaded weekday would contain this time entry
 					var matchingTimeSummary = LoadedWeekSummaryCache.Lookup(createdTimeEntry.Start.Date);
@@ -198,7 +198,7 @@ public class DateViewModel : ViewModelBase
 					if (matchingTimeSummary.HasValue)
 					{
 						// We do so set the selected time summary to the existing one
-						SelectedTimeSummary = matchingTimeSummary.Value;
+						UpdateSelectedSummary(matchingTimeSummary.Value);
 
 						AddOrUpdateEntryInCurrentSelectedDate(createdTimeEntry);
 					}
@@ -213,7 +213,7 @@ public class DateViewModel : ViewModelBase
 						LoadSelectedTimeEntriesForDate(createdTimeEntry.Start, _timeManager);
 
 						// Then set the selected time summary
-						SelectedTimeSummary = LoadedWeekSummaryCache.Lookup(createdTimeEntry.Start.Date).Value;
+						UpdateSelectedSummary(LoadedWeekSummaryCache.Lookup(createdTimeEntry.Start.Date).Value);
 					}
 				}
 				else
@@ -250,6 +250,28 @@ public class DateViewModel : ViewModelBase
 				// Refresh the week summary for the selected date
 				UpdateTimeEntrySummaryForDate(timeEntryDto.Start, _timeManager);
 			});
+		}
+	}
+
+	/// <summary>
+	/// Updates the selected weekday summary to the given value, if it is not null,
+	/// also sets <see cref="SummarisedTimeEntryViewModel.Selected"/> to true
+	/// </summary>
+	/// <param name="summarisedTimeEntryViewModel"></param>
+	private void UpdateSelectedSummary(SummarisedTimeEntryViewModel? summarisedTimeEntryViewModel)
+	{
+		// clear the selected state on the previous value
+		if (SelectedTimeSummary != null)
+		{
+			SelectedTimeSummary.Selected = false;
+		}
+
+		SelectedTimeSummary = summarisedTimeEntryViewModel;
+
+		// If we're setting the selected value a not-null value, set selected to true
+		if (SelectedTimeSummary != null)
+		{
+			SelectedTimeSummary.Selected = true;
 		}
 	}
 

--- a/Nulah.TimeTracker/Controls/DateView.axaml.cs
+++ b/Nulah.TimeTracker/Controls/DateView.axaml.cs
@@ -362,8 +362,10 @@ public class DateViewModel : ViewModelBase
 	/// <param name="timeManager"></param>
 	private void UpdateTimeEntrySummaryForDate(DateTimeOffset date, TimeManager timeManager)
 	{
+		var loadedSummary = LoadedWeekSummaryCache.Lookup(date.Date);
+
 		// Don't attempt to update a summary for a date that isn't loaded.
-		if (!LoadedWeekSummaryCache.Lookup(date.Date).HasValue)
+		if (!loadedSummary.HasValue)
 		{
 			return;
 		}
@@ -383,7 +385,9 @@ public class DateViewModel : ViewModelBase
 		// TODO: do nothing if the date param does not exist in the loaded week summary
 		if (summaries.SingleOrDefault() is { } foundSummary)
 		{
-			LoadedWeekSummaryCache.AddOrUpdate(new SummarisedTimeEntryViewModel(foundSummary));
+			loadedSummary.Value.SummarisedTimeEntryDto.Summaries = foundSummary.Summaries;
+			loadedSummary.Value.Selected = true;
+			LoadedWeekSummaryCache.AddOrUpdate(loadedSummary.Value);
 		}
 	}
 

--- a/Nulah.TimeTracker/Controls/DateView.axaml.cs
+++ b/Nulah.TimeTracker/Controls/DateView.axaml.cs
@@ -197,10 +197,14 @@ public class DateViewModel : ViewModelBase
 					// If it would, set it to the current selected, and add it to what we have displayed
 					if (matchingTimeSummary.HasValue)
 					{
-						// We do so set the selected time summary to the existing one
+						// Load the time entries for the date we're switching to
+						LoadSelectedTimeEntriesForDate(createdTimeEntry.Start, _timeManager);
+						
+						// Update the target summary date to reflect the new entry
+						UpdateTimeEntrySummaryForDate(createdTimeEntry.Start, _timeManager);
+						
+						// Set the selected time summary to the existing one
 						UpdateSelectedSummary(matchingTimeSummary.Value);
-
-						AddOrUpdateEntryInCurrentSelectedDate(createdTimeEntry);
 					}
 					else
 					{

--- a/Nulah.TimeTracker/Controls/DateView.axaml.cs
+++ b/Nulah.TimeTracker/Controls/DateView.axaml.cs
@@ -233,6 +233,30 @@ public class DateViewModel : ViewModelBase
 	}
 
 	/// <summary>
+	/// Updates <see cref="SelectedDateTimeEntriesCache"/> based on the incoming <paramref name="updatedTimeEntryDto"/>,
+	/// and refreshes the date summary it belongs to.
+	/// <para>
+	///	This method assumes that the updating time entry belongs to the selected summary. If it does not in the future
+	/// then this may cause unintended behaviours and cause the selected summary to drift out of sync
+	/// </para>
+	/// </summary>
+	/// <param name="updatedTimeEntryDto"></param>
+	public void UpdateTimeEntry(TimeEntryDto updatedTimeEntryDto)
+	{
+		if (_timeManager != null)
+		{
+			Dispatcher.UIThread.Invoke(() =>
+			{
+				// TODO: check that the currently selected summary belongs to the updating time entry. If it doesn't, do not
+				// update the cache
+				SelectedDateTimeEntriesCache.AddOrUpdate(updatedTimeEntryDto);
+				// lazy refresh the date summaries
+				SelectWeekFromDateInternal(updatedTimeEntryDto.Start, _timeManager);
+			});
+		}
+	}
+
+	/// <summary>
 	/// Loads all <see cref="TimeEntryDto"/>'s for the given date into <see cref="SelectedDateTimeEntriesCache"/>.
 	/// </summary>
 	/// <param name="start"></param>
@@ -288,14 +312,6 @@ public class DateViewModel : ViewModelBase
 			.ToList();
 
 		TimeEntrySummaries = populatedSummaries;
-	}
-
-	public void UpdateTimeEntry(TimeEntryDto updatedTimeEntryDto)
-	{
-		Dispatcher.UIThread.Invoke(() =>
-		{
-			SelectedDateTimeEntriesCache.AddOrUpdate(updatedTimeEntryDto);
-		});
 	}
 
 	/// <summary>

--- a/Nulah.TimeTracker/Controls/DateView.axaml.cs
+++ b/Nulah.TimeTracker/Controls/DateView.axaml.cs
@@ -239,15 +239,16 @@ public class DateViewModel : ViewModelBase
 	/// <param name="timeEntryDto"></param>
 	public void UpdateTimeEntry(TimeEntryDto timeEntryDto)
 	{
-		if (_timeManager != null)
+		if (_timeManager != null
+		    && _selectedTimeSummary != null
+		    && _selectedTimeSummary.SummarisedTimeEntryDto.Date == timeEntryDto.Start.Date
+		   )
 		{
 			Dispatcher.UIThread.Invoke(() =>
 			{
-				// TODO: check that the currently selected summary belongs to the updating time entry. If it doesn't, do not
-				// update the cache
 				SelectedDateTimeEntriesCache.AddOrUpdate(timeEntryDto);
-				// lazy refresh the date summaries
-				LoadWeekFromDateInternal(timeEntryDto.Start, _timeManager);
+				// Refresh the week summary for the selected date
+				UpdateTimeEntrySummaryForDate(timeEntryDto.Start, _timeManager);
 			});
 		}
 	}

--- a/Nulah.TimeTracker/Controls/FlexingTimeSegment.axaml.cs
+++ b/Nulah.TimeTracker/Controls/FlexingTimeSegment.axaml.cs
@@ -7,10 +7,10 @@ namespace Nulah.TimeTracker.Controls;
 
 public partial class FlexingTimeSegment : UserControl
 {
-	public static readonly StyledProperty<TimeEntrySummaryDto> TimeEntrySummaryProperty
-		= AvaloniaProperty.Register<FlexingTimeSegment, TimeEntrySummaryDto>(nameof(TimeEntrySummary));
+	public static readonly StyledProperty<TimeEntrySummaryDto?> TimeEntrySummaryProperty
+		= AvaloniaProperty.Register<FlexingTimeSegment, TimeEntrySummaryDto?>(nameof(TimeEntrySummary));
 
-	public TimeEntrySummaryDto TimeEntrySummary
+	public TimeEntrySummaryDto? TimeEntrySummary
 	{
 		get => GetValue(TimeEntrySummaryProperty);
 		set => SetValue(TimeEntrySummaryProperty, value);
@@ -56,11 +56,13 @@ public partial class FlexingTimeSegment : UserControl
 	{
 		base.OnPropertyChanged(change);
 
-		if (change.Property != TotalBoundaryProperty || TimeEntrySummary.Duration == null)
+		// TODO: this method gets called for every property change so definitely look at how to
+		// improve this so it only gets called once all properties we care about are available
+		if (change.Property != TotalBoundaryProperty || TimeEntrySummary?.Duration == null)
 		{
 			return;
 		}
-		
+
 		var percent = TimeEntrySummary.Duration.Value.Ticks / (double)TotalDuration.Ticks;
 		DisplayWidth = percent * TotalBoundary.Right;
 	}


### PR DESCRIPTION
Fix week summaries not updating correctly when creating or updating time entries
- refactor towards usage of SourceCache where possible
- add selected week summary styling

Resolves #3, #14